### PR TITLE
Add global settings

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -7,7 +7,7 @@ This directory contains helm charts to install `critik8s`.
 This chart will install the RabbitMq operator to deploy and manage RabbitMQ clusters. See <https://github.com/rabbitmq/cluster-operator>
 
   ```bash
-  helm install rabbitmq-operator charts/rabbitmq-operator/ -n rabbitmq --create-namespace
+  helm install rabbitmq-operator charts/rabbitmq-operator/ -n critik8s --create-namespace
   ```
 
 ## RabbitMq Cluster
@@ -15,7 +15,7 @@ This chart will install the RabbitMq operator to deploy and manage RabbitMQ clus
 This chart will install the RabbitMq Custer, which provides the messaging services inside your cluster.
 
   ```bash
-  helm install rabbitmq-cluster charts/rabbitmq-cluster/ -n rabbitmq --create-namespace
+  helm install rabbitmq-cluster charts/rabbitmq-cluster/ --values settings.yaml -n critik8s --create-namespace
   ```
 
 ## Test RabbitMq Cluster

--- a/charts/rabbitmq-cluster/templates/rabbitmq-cluster.yaml
+++ b/charts/rabbitmq-cluster/templates/rabbitmq-cluster.yaml
@@ -17,8 +17,8 @@ spec:
     additionalConfig: |
       log.console.level = {{ .Values.rabbitmq.config.logLevel }}
       channel_max = 700
-      default_user= {{ .Values.rabbitmq.config.username }}
-      default_pass = {{ .Values.rabbitmq.config.password }}
+      default_user= {{ .Values.settings.rabbitmq.username }}
+      default_pass = {{ .Values.settings.rabbitmq.password }}
       default_user_tags.administrator = true
   service:
     type: LoadBalancer

--- a/charts/rabbitmq-cluster/values.yaml
+++ b/charts/rabbitmq-cluster/values.yaml
@@ -10,5 +10,3 @@ cluster:
 rabbitmq:
   config:
     logLevel: info
-    username: admin
-    password: password

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,0 +1,4 @@
+settings:
+  rabbitmq:
+    username: admin
+    password: password


### PR DESCRIPTION
Adding critik8s global settings.
Some settings need to be global and shared across critik8s microservices helm charts.