### PR TITLE
Implement External Service for Rabbitmq service

### DIFF
--- a/charts/critik8s/templates/config-map.yaml
+++ b/charts/critik8s/templates/config-map.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: data-collector
 data:
+  AMQP_HOST: {{ .Values.amqpProxy.externalService.host }}
+  AMQP_PORT: ""
   AMQP_USERNAME: {{ .Values.settings.rabbitmq.username }}
   AMQP_PASSWORD: {{ .Values.settings.rabbitmq.password }}
   ROUTE_1: {{ .Values.settings.rabbitmq.routing.key1 }}
@@ -15,6 +17,8 @@ metadata:
   labels:
   {{- include "monitor-backend.labels" . | nindent 4 }}
 data:
+  AMQP_HOST: {{ .Values.amqpProxy.externalService.host }}
+  AMQP_PORT: ""
   AMQP_USERNAME: {{ .Values.settings.rabbitmq.username }}
   AMQP_PASSWORD: {{ .Values.settings.rabbitmq.password }}
   AMQP_PROXY_PATH: {{ .Values.settings.amqpProxy.path }}

--- a/charts/critik8s/templates/config-map.yaml
+++ b/charts/critik8s/templates/config-map.yaml
@@ -9,6 +9,7 @@ data:
   AMQP_PASSWORD: {{ .Values.settings.rabbitmq.password }}
   ROUTE_1: {{ .Values.settings.rabbitmq.routing.key1 }}
   ROUTE_3: {{ .Values.settings.rabbitmq.routing.key3 }}
+  ROUTE_4: {{ .Values.settings.rabbitmq.routing.key4 }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -24,3 +25,4 @@ data:
   AMQP_PROXY_PATH: {{ .Values.settings.amqpProxy.path }}
   ROUTE_1: {{ .Values.settings.rabbitmq.routing.key1 }}
   ROUTE_2: {{ .Values.settings.rabbitmq.routing.key2 }}
+  ROUTE_4: {{ .Values.settings.rabbitmq.routing.key4 }}

--- a/charts/critik8s/templates/deployment.yaml
+++ b/charts/critik8s/templates/deployment.yaml
@@ -18,14 +18,14 @@ spec:
       {{- include "amqp-proxy.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-      - args: {{- toYaml .Values.amqpProxy.amqpProxy.args | nindent 8 }}
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ .Values.amqpProxy.amqpProxy.image.repository }}:{{ .Values.amqpProxy.amqpProxy.image.tag
-          | default .Chart.AppVersion }}
-        name: amqp-proxy
-        resources: {}
+        - args: [ "--upstream", "tcp://{{ .Values.amqpProxy.externalService.host }}" ]
+          env:
+          - name: KUBERNETES_CLUSTER_DOMAIN
+            value: {{ quote .Values.kubernetesClusterDomain }}
+          image: {{ .Values.amqpProxy.amqpProxy.image.repository }}:{{ .Values.amqpProxy.amqpProxy.image.tag
+            | default .Chart.AppVersion }}
+          name: amqp-proxy
+          resources: {}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/critik8s/templates/service.yaml
+++ b/charts/critik8s/templates/service.yaml
@@ -42,3 +42,11 @@ spec:
   {{- include "amqp-proxy.selectorLabels" . | nindent 4 }}
   ports:
 	{{- .Values.amqpProxy.ports | toYaml | nindent 2 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.amqpProxy.externalService.host }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.amqpProxy.externalService.externalName }}

--- a/charts/critik8s/values.yaml
+++ b/charts/critik8s/values.yaml
@@ -1,9 +1,6 @@
 kubernetesClusterDomain: cluster.local
 amqpProxy:
   amqpProxy:
-    args:
-    - --upstream
-    - tcp://$(RABBITMQ_CLUSTER_SERVICE_HOST):$(RABBITMQ_CLUSTER_SERVICE_PORT)
     image:
       repository: cloudamqp/websocket-tcp-relay
       tag: latest
@@ -13,6 +10,9 @@ amqpProxy:
     targetPort: 15670
   replicas: 1
   type: ClusterIP
+  externalService:
+    host: critik8s-amqp
+    externalName: "rabbitmq-cluster.rabbitmq.svc.cluster.local"
 dataCollector:
   replicaCount: 1
   image:

--- a/charts/settings.yaml
+++ b/charts/settings.yaml
@@ -9,5 +9,7 @@ settings:
       key2: DZC8yP
       # data-collector <-> rule-evaluator
       key3: kxMjFs
+      # data-collector <-> monitor-backend
+      key4: dpTqMl
   amqpProxy:
     path: amqp-proxy

--- a/package.json
+++ b/package.json
@@ -10,10 +10,9 @@
     "cluster:create:s3": "k3d cluster create critik8s -p '80:80@loadbalancer' --servers 3",
     "cluster:create:a2": "k3d cluster create critik8s -p '80:80@loadbalancer' --agents 2",
     "cluster:delete": "k3d cluster delete critik8s",
-    "critik8s:create:ns": "kubectl create ns critik8s",
-    "rabbitmq:install": "helm install rabbitmq-operator charts/rabbitmq-operator -n critik8s && helm install rabbitmq-cluster charts/rabbitmq-cluster --values charts/settings.yaml -n critik8s",
+    "rabbitmq:install": "helm install rabbitmq-operator charts/rabbitmq-operator -n rabbitmq --create-namespace && helm install rabbitmq-cluster charts/rabbitmq-cluster --values charts/settings.yaml -n rabbitmq",
     "rabbitmq:uninstall": "helm uninstall rabbitmq-cluster -n critik8s && helm uninstall rabbitmq-operator -n critik8s",
-    "critik8s:install": "helm install critik8s charts/critik8s --values charts/settings.yaml -n critik8s",
+    "critik8s:install": "helm install critik8s charts/critik8s --values charts/settings.yaml -n critik8s --create-namespace",
     "critik8s:uninstall": "helm uninstall critik8s -n critik8s",
     "critik8s:monitor:install": "cd src/monitor && npm install",
     "critik8s:monitor:rundev": "cd src/monitor && npm run dev"

--- a/src/data-collector/amqp/client.go
+++ b/src/data-collector/amqp/client.go
@@ -1,14 +1,26 @@
 package amqp
 
 import (
+	"context"
 	"data-collector/config"
 	e "data-collector/error"
+	k8s "data-collector/kubernetes"
 	"fmt"
+	"log"
+	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-func Connect() *amqp.Connection {
+var routingKeys = config.GetRoutingKeys()
+var conn *amqp.Connection
+
+func Init() *amqp.Connection {
+	conn = connect()
+	return conn
+}
+
+func connect() *amqp.Connection {
 	c := config.GetAmqpConfig()
 
 	address := fmt.Sprintf("amqp://%s:%s@%s:%s/", c.Username, c.Password, c.Service, c.Port)
@@ -17,4 +29,66 @@ func Connect() *amqp.Connection {
 	e.FailOnError(err, "Failed to connect to RabbitMQ")
 
 	return conn
+}
+
+func RpcAux() {
+	ch, err := conn.Channel()
+	e.FailOnError(err, "Failed to open a channel")
+	defer ch.Close()
+
+	q, err := ch.QueueDeclare(
+		routingKeys.MonitorBackend, // name
+		false,                      // durable
+		false,                      // delete when unused
+		false,                      // exclusive
+		false,                      // no-wait
+		nil,                        // arguments
+	)
+	e.FailOnError(err, "Failed to declare a queue")
+
+	err = ch.Qos(
+		1,     // prefetch count
+		0,     // prefetch size
+		false, // global
+	)
+	e.FailOnError(err, "Failed to set QoS")
+
+	msgs, err := ch.Consume(
+		q.Name, // queue
+		"",     // consumer
+		false,  // auto-ack
+		false,  // exclusive
+		false,  // no-local
+		false,  // no-wait
+		nil,    // args
+	)
+	e.FailOnError(err, "Failed to register a consumer")
+
+	var forever chan struct{}
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		for d := range msgs {
+
+			response := k8s.GetResource(d.CorrelationId)
+
+			err = ch.PublishWithContext(ctx,
+				"",        // exchange
+				d.ReplyTo, // routing key
+				false,     // mandatory
+				false,     // immediate
+				amqp.Publishing{
+					ContentType:   "text/plain",
+					CorrelationId: d.CorrelationId,
+					Body:          []byte(response),
+				})
+			e.FailOnError(err, "Failed to publish a message")
+
+			d.Ack(false)
+		}
+	}()
+
+	log.Printf(" [*] Awaiting RPC requests")
+	<-forever
 }

--- a/src/data-collector/amqp/manager.go
+++ b/src/data-collector/amqp/manager.go
@@ -1,0 +1,52 @@
+package amqp
+
+import (
+	"context"
+	"data-collector/config"
+	e "data-collector/error"
+	k8s "data-collector/kubernetes"
+	"log"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+func PublishSubscribeTest() {
+	ch, err := conn.Channel()
+	e.FailOnError(err, "Failed to open a channel")
+	defer ch.Close()
+
+	err = ch.ExchangeDeclare(
+		"logs_topic", // name
+		"topic",      // type
+		true,         // durable
+		false,        // auto-deleted
+		false,        // internal
+		false,        // no-wait
+		nil,          // arguments
+	)
+	e.FailOnError(err, "Failed to declare an exchange")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	nodes := k8s.GetNodes()
+
+	routingKeys := config.GetRoutingKeys()
+
+	for {
+		err = ch.PublishWithContext(ctx,
+			"logs_topic",        // exchange
+			routingKeys.Monitor, // routing key for monitor
+			false,               // mandatory
+			false,               // immediate
+			amqp.Publishing{
+				ContentType: "text/plain",
+				Body:        []byte(nodes),
+			})
+		e.FailOnError(err, "Failed to publish a message")
+
+		log.Printf(" [x] Sent nodes")
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/src/data-collector/config/config.go
+++ b/src/data-collector/config/config.go
@@ -10,7 +10,8 @@ type AmqpConfig struct {
 }
 
 type RoutingKeys struct {
-	Monitor string
+	Monitor        string
+	MonitorBackend string
 }
 
 func GetAmqpConfig() AmqpConfig {
@@ -28,7 +29,8 @@ func GetAmqpConfig() AmqpConfig {
 func GetRoutingKeys() RoutingKeys {
 
 	rk := RoutingKeys{
-		Monitor: os.Getenv("ROUTE_1"),
+		Monitor:        os.Getenv("ROUTE_1"),
+		MonitorBackend: os.Getenv("ROUTE_4"),
 	}
 
 	return rk

--- a/src/data-collector/config/config.go
+++ b/src/data-collector/config/config.go
@@ -16,8 +16,8 @@ type RoutingKeys struct {
 func GetAmqpConfig() AmqpConfig {
 
 	c := AmqpConfig{
-		Service:  os.Getenv("RABBITMQ_CLUSTER_SERVICE_HOST"),
-		Port:     os.Getenv("RABBITMQ_CLUSTER_SERVICE_PORT"),
+		Service:  os.Getenv("AMQP_HOST"),
+		Port:     os.Getenv("AMQP_PORT"),
 		Username: os.Getenv("AMQP_USERNAME"),
 		Password: os.Getenv("AMQP_PASSWORD"),
 	}

--- a/src/data-collector/data-collector.go
+++ b/src/data-collector/data-collector.go
@@ -1,77 +1,19 @@
 package main
 
 import (
-	"context"
-	amqpClient "data-collector/amqp"
-	"data-collector/config"
-	e "data-collector/error"
-	k8s "data-collector/kubernetes"
-	"encoding/json"
-	"fmt"
-	"log"
-	"os"
-	"strings"
-	"time"
-
-	amqp "github.com/rabbitmq/amqp091-go"
+	"data-collector/amqp"
 )
 
 func main() {
+	var forever chan struct{}
 
-	conn := amqpClient.Connect()
+	conn := amqp.Init()
 	defer conn.Close()
 
-	ch, err := conn.Channel()
-	e.FailOnError(err, "Failed to open a channel")
-	defer ch.Close()
+	go amqp.RpcAux()
 
-	err = ch.ExchangeDeclare(
-		"logs_topic", // name
-		"topic",      // type
-		true,         // durable
-		false,        // auto-deleted
-		false,        // internal
-		false,        // no-wait
-		nil,          // arguments
-	)
-	e.FailOnError(err, "Failed to declare an exchange")
+	// TODO remove, for proves Publish Subscribe only
+	amqp.PublishSubscribeTest()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	nodes := k8s.GetNodes()
-
-	body, err := json.Marshal(nodes)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	routingKeys := config.GetRoutingKeys()
-
-	for {
-		err = ch.PublishWithContext(ctx,
-			"logs_topic",        // exchange
-			routingKeys.Monitor, // routing key for monitor
-			false,               // mandatory
-			false,               // immediate
-			amqp.Publishing{
-				ContentType: "text/plain",
-				Body:        []byte(string(body)),
-			})
-		e.FailOnError(err, "Failed to publish a message")
-
-		log.Printf(" [x] Sent nodes")
-		time.Sleep(5 * time.Second)
-	}
-}
-
-func bodyFrom(args []string) string {
-	var s string
-	if (len(args) < 3) || os.Args[2] == "" {
-		s = "ciao"
-	} else {
-		s = strings.Join(args[2:], " ")
-	}
-	return s
+	<-forever
 }

--- a/src/data-collector/kubernetes/manager.go
+++ b/src/data-collector/kubernetes/manager.go
@@ -2,18 +2,38 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var clientset = InitKubeconfig()
 
-func GetNodes() *v1.NodeList {
+func toString(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+
+	return string(data)
+}
+
+func GetNodes() string {
 	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		panic(err.Error())
 	}
 
-	return nodes
+	return toString(nodes)
+}
+
+func GetPods() string {
+	pods, err := clientset.CoreV1().Pods("rabbitmq").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return toString(pods)
 }

--- a/src/data-collector/kubernetes/resources.go
+++ b/src/data-collector/kubernetes/resources.go
@@ -1,0 +1,18 @@
+package kubernetes
+
+import (
+	"log"
+)
+
+var resources = map[string]func() string{
+	"cluster.resource.nodes": GetNodes,
+	"cluster.resource.pods":  GetPods,
+}
+
+func GetResource(id string) string {
+	f := resources[id]
+
+	log.Printf(" [%s]: sending resource", id)
+
+	return f()
+}

--- a/src/monitor-backend/amqp/client.go
+++ b/src/monitor-backend/amqp/client.go
@@ -1,4 +1,77 @@
 package amqp
 
-func Connect() {
+import (
+	"context"
+	"fmt"
+	"monitor-backend/config"
+	e "monitor-backend/error"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+var routingKeys = config.GetRoutingKeys()
+var conn *amqp.Connection
+
+func Init() *amqp.Connection {
+	conn = connect()
+	return conn
+}
+
+func connect() *amqp.Connection {
+	c := config.GetAmqpConfig()
+
+	address := fmt.Sprintf("amqp://%s:%s@%s:%s/", c.Username, c.Password, c.Service, c.Port)
+
+	conn, err := amqp.Dial(address)
+	e.FailOnError(err, "Failed to connect to RabbitMQ")
+
+	return conn
+}
+
+func RpcRequest(entity string, id string) string {
+	ch, err := conn.Channel()
+	e.FailOnError(err, "Failed to open a channel")
+	defer ch.Close()
+
+	q, err := ch.QueueDeclare(
+		"",    // name
+		false, // durable
+		false, // delete when unused
+		true,  // exclusive
+		false, // noWait
+		nil,   // arguments
+	)
+	e.FailOnError(err, "Failed to declare a queue")
+
+	msgs, err := ch.Consume(
+		q.Name, // queue
+		"",     // consumer
+		true,   // auto-ack
+		false,  // exclusive
+		false,  // no-local
+		false,  // no-wait
+		nil,    // args
+	)
+	e.FailOnError(err, "Failed to register a consumer")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = ch.PublishWithContext(ctx,
+		"",                        // exchange
+		routingKeys.DataCollector, // routing key
+		false,                     // mandatory
+		false,                     // immediate
+		amqp.Publishing{
+			ContentType:   "text/plain",
+			CorrelationId: entity,
+			ReplyTo:       q.Name,
+			Body:          []byte(id),
+		})
+	e.FailOnError(err, "Failed to publish a message")
+
+	delivery := <-msgs
+
+	return string(delivery.Body)
 }

--- a/src/monitor-backend/amqp/manager.go
+++ b/src/monitor-backend/amqp/manager.go
@@ -1,0 +1,35 @@
+package amqp
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+func bodyFrom(args []string) string {
+	var s string
+	if (len(args) < 2) || os.Args[1] == "" {
+		s = "hello"
+	} else {
+		s = strings.Join(args[1:], " ")
+	}
+	return s
+}
+
+func GetNodes() any {
+	msg := RpcRequest("cluster.resource.nodes", "")
+
+	var nodes map[string]interface{}
+	json.Unmarshal([]byte(msg), &nodes)
+
+	return nodes
+}
+
+func GetPods() any {
+	msg := RpcRequest("cluster.resource.pods", "")
+
+	var pods map[string]interface{}
+	json.Unmarshal([]byte(msg), &pods)
+
+	return pods
+}

--- a/src/monitor-backend/api/manager.go
+++ b/src/monitor-backend/api/manager.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"monitor-backend/amqp"
 	"monitor-backend/config"
 	"monitor-backend/models"
 	"monitor-backend/utils"
@@ -9,7 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-var monitorConfig = config.Get()
+var monitorConfig = config.GetMonitorConfig()
 
 func Ping(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
@@ -25,4 +26,14 @@ func Rules(c *gin.Context) {
 	rule := utils.ParseFile[models.Rule]("rules/RWO.yaml")
 
 	c.JSON(200, rule)
+}
+
+func Nodes(c *gin.Context) {
+	nodes := amqp.GetNodes()
+	c.JSON(200, nodes)
+}
+
+func Pods(c *gin.Context) {
+	pods := amqp.GetPods()
+	c.JSON(200, pods)
 }

--- a/src/monitor-backend/api/routes.go
+++ b/src/monitor-backend/api/routes.go
@@ -6,7 +6,11 @@ import (
 
 func Routes(engine *gin.Engine) {
 
-	engine.GET("/ping", Ping)
-	engine.GET("/auth", Auth)
-	engine.GET("/rules", Rules)
+	g := engine.Group("v1")
+
+	g.GET("/ping", Ping)
+	g.GET("/auth", Auth)
+	g.GET("/rules", Rules)
+	g.GET("/nodes", Nodes)
+	g.GET("/pods", Pods)
 }

--- a/src/monitor-backend/config/config.go
+++ b/src/monitor-backend/config/config.go
@@ -2,16 +2,47 @@ package config
 
 import "os"
 
-type Config struct {
+type AmqpConfig struct {
+	Service  string
+	Port     string
+	Username string
+	Password string
+}
+
+type RoutingKeys struct {
+	DataCollector string
+}
+
+type MonitorConfig struct {
 	RabbitmqPath            string `json:"rabbitmqPath"`
 	RabbitmqUsername        string `json:"rabbitmqUsername"`
 	RabbitmqPassword        string `json:"rabbitmqPassword"`
-	DataCollectorRoutingKey string `json:"dataCollectorRoutingKey"` // TO BE REMOVED, ONLY FOR TESTS
+	DataCollectorRoutingKey string `json:"dataCollectorRoutingKey"`
 }
 
-func Get() Config {
+func GetAmqpConfig() AmqpConfig {
+	c := AmqpConfig{
+		Service:  os.Getenv("AMQP_HOST"),
+		Port:     os.Getenv("AMQP_PORT"),
+		Username: os.Getenv("AMQP_USERNAME"),
+		Password: os.Getenv("AMQP_PASSWORD"),
+	}
 
-	c := Config{
+	return c
+}
+
+func GetRoutingKeys() RoutingKeys {
+
+	rk := RoutingKeys{
+		DataCollector: os.Getenv("ROUTE_4"),
+	}
+
+	return rk
+}
+
+func GetMonitorConfig() MonitorConfig {
+
+	c := MonitorConfig{
 		RabbitmqPath:            os.Getenv("AMQP_PROXY_PATH"),
 		RabbitmqUsername:        os.Getenv("AMQP_USERNAME"),
 		RabbitmqPassword:        os.Getenv("AMQP_PASSWORD"),

--- a/src/monitor-backend/error/error.go
+++ b/src/monitor-backend/error/error.go
@@ -1,0 +1,9 @@
+package error
+
+import "log"
+
+func FailOnError(err error, msg string) {
+	if err != nil {
+		log.Panicf("%s: %s", msg, err)
+	}
+}

--- a/src/monitor-backend/monitor-backend.go
+++ b/src/monitor-backend/monitor-backend.go
@@ -9,7 +9,8 @@ import (
 
 func main() {
 
-	amqp.Connect()
+	conn := amqp.Init()
+	defer conn.Close()
 
 	engine := gin.Default()
 	engine.Use(api.CORSMiddleware())

--- a/src/monitor-backend/utils/string.go
+++ b/src/monitor-backend/utils/string.go
@@ -1,0 +1,15 @@
+package utils
+
+import "math/rand"
+
+func randInt(min int, max int) int {
+	return min + rand.Intn(max-min)
+}
+
+func RandomString(l int) string {
+	bytes := make([]byte, l)
+	for i := 0; i < l; i++ {
+		bytes[i] = byte(randInt(65, 90))
+	}
+	return string(bytes)
+}


### PR DESCRIPTION
- Add the k8s external service to allow communication from `critik8s` namespace to rabbitmq service (`rabbitmq` namespace)
- Reflect changes in Helm charts
- Refactoring `data-collector` and `monitor-backend` code
- Implement RPC mechanism in `data-collector`